### PR TITLE
refactor(protocol-params): move eip-7685 logic to seismic-crate

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -1,7 +1,7 @@
 //! Ethereum block executor.
 
 use super::{
-    dao_fork, eip6110, protocol_params,
+    dao_fork, eip6110,
     receipt_builder::{AlloyReceiptBuilder, ReceiptBuilder, ReceiptBuilderCtx},
     spec::{EthExecutorSpec, EthSpec},
     EthEvmFactory,
@@ -165,21 +165,10 @@ where
             let deposit_requests =
                 eip6110::parse_deposits_from_receipts(&self.spec, &self.receipts)?;
 
-            // Collect all protocol param requests
-            let protocol_param_requests =
-                protocol_params::parse_protocol_params_from_receipts(&self.receipts)?;
-
             let mut requests = Requests::default();
 
             if !deposit_requests.is_empty() {
                 requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
-            }
-
-            if !protocol_param_requests.is_empty() {
-                requests.push_request_with_type(
-                    protocol_params::PROTOCOL_PARAM_REQUEST_TYPE,
-                    protocol_param_requests,
-                );
             }
 
             requests.extend(self.system_caller.apply_post_execution_changes(&mut self.evm)?);

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -22,7 +22,6 @@ pub use block::*;
 
 pub mod dao_fork;
 pub mod eip6110;
-pub mod protocol_params;
 pub mod receipt_builder;
 pub mod spec;
 

--- a/crates/seismic-evm/Cargo.toml
+++ b/crates/seismic-evm/Cargo.toml
@@ -20,6 +20,7 @@ alloy-primitives.workspace = true
 alloy-hardforks.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-sol-types.workspace = true
 
 # revm
 revm.workspace = true

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -137,8 +137,9 @@ where
         // Add Seismic-specific eip-7685 protocol param requests
         // Note that according to https://eips.ethereum.org/EIPS/eip-7685#ordering,
         // requests must be ordered by ascending type. Given that PROTOCOL_PARAM_REQUEST_TYPE=255,
-        // it'll always need to be ordered behind all the ethereum requests even for future hardforks.
-        // Therefore it makes sense to add these here, after the ethereum requests have been added by inner.finish().
+        // it'll always need to be ordered behind all the ethereum requests even for future
+        // hardforks. Therefore it makes sense to add these here, after the ethereum
+        // requests have been added by inner.finish().
         if self.spec.is_prague_active_at_timestamp(evm.block().timestamp.saturating_to()) {
             let protocol_param_requests =
                 protocol_params::parse_protocol_params_from_receipts(&result.receipts)?;

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -44,6 +44,7 @@ where
 {
     inner: EthBlockExecutor<'a, Evm, Spec, R>,
     purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+    spec: Spec,
 }
 
 impl<'a, E, Spec, R> SeismicBlockExecutor<'a, E, Spec, R>
@@ -61,7 +62,11 @@ where
         receipt_builder: R,
         purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
     ) -> Self {
-        Self { inner: EthBlockExecutor::new(evm, ctx, spec, receipt_builder), purpose_keys }
+        Self {
+            inner: EthBlockExecutor::new(evm, ctx, spec.clone(), receipt_builder),
+            purpose_keys,
+            spec,
+        }
     }
 }
 
@@ -125,7 +130,28 @@ where
     }
 
     fn finish(self) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
-        self.inner.finish()
+        use crate::protocol_params;
+
+        let (evm, mut result) = self.inner.finish()?;
+
+        // Add Seismic-specific eip-7685 protocol param requests
+        // Note that according to https://eips.ethereum.org/EIPS/eip-7685#ordering,
+        // requests must be ordered by ascending type. Given that PROTOCOL_PARAM_REQUEST_TYPE=255,
+        // it'll always need to be ordered behind all the ethereum requests even for future hardforks.
+        // Therefore it makes sense to add these here, after the ethereum requests have been added by inner.finish().
+        if self.spec.is_prague_active_at_timestamp(evm.block().timestamp.saturating_to()) {
+            let protocol_param_requests =
+                protocol_params::parse_protocol_params_from_receipts(&result.receipts)?;
+
+            if !protocol_param_requests.is_empty() {
+                result.requests.push_request_with_type(
+                    protocol_params::PROTOCOL_PARAM_REQUEST_TYPE,
+                    protocol_param_requests,
+                );
+            }
+        }
+
+        Ok((evm, result))
     }
 
     fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {

--- a/crates/seismic-evm/src/lib.rs
+++ b/crates/seismic-evm/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, IntoTxEnv};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use core::ops::{Deref, DerefMut};
@@ -31,6 +33,7 @@ use seismic_revm::{
 
 pub mod block;
 pub mod hardfork;
+pub mod protocol_params;
 
 /// Seismic EVM implementation.
 ///
@@ -153,7 +156,7 @@ where
                 kind: TxKind::Call(contract),
                 // Explicitly set nonce to 0 so revm does not do any nonce checks
                 nonce: 0,
-                gas_limit: 30_000_000,
+                gas_limit: crate::protocol_params::SYSTEM_CALL_GAS_LIMIT,
                 value: U256::ZERO,
                 data,
                 // Setting the gas price to zero enforces that no value is transferred as part of

--- a/crates/seismic-evm/src/protocol_params.rs
+++ b/crates/seismic-evm/src/protocol_params.rs
@@ -1,7 +1,13 @@
-//! Seismic protocol param requests parsing
-use crate::block::BlockValidationError;
+//! Seismic protocol parameter requests and system call configuration.
+//!
+//! This module contains all Seismic-specific protocol parameter logic:
+//! - Protocol parameter contract address and request type
+//! - Event parsing from transaction receipts
+//! - System call gas limit constant
+
 use alloc::{string::ToString, vec::Vec};
 use alloy_consensus::TxReceipt;
+use alloy_evm::block::BlockValidationError;
 use alloy_primitives::{address, Address, Bytes, Log};
 use alloy_sol_types::{sol, SolEvent};
 
@@ -17,6 +23,12 @@ pub const SEISMIC_PROTOCOL_PARAMS_CONTRACT: Address =
 
 /// The [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) request type for protocol param requests.
 pub const PROTOCOL_PARAM_REQUEST_TYPE: u8 = 0xFF;
+
+/// Gas limit for system calls (protocol param updates, deposits, etc.)
+///
+/// These calls are executed with gas_price = 0 and don't count against the
+/// block gas limit. Used in `SeismicEvm::transact_system_call()`.
+pub const SYSTEM_CALL_GAS_LIMIT: u64 = 30_000_000;
 
 const PROTOCOL_PARAM_MAX_BYTES_SIZE: usize = 1 + 100;
 


### PR DESCRIPTION
This PR is purely a refactor of the code added in https://github.com/SeismicSystems/seismic-evm/pull/28

This is a small first step towards my goal to minimize our forks and start using reth/revm/evm more as an sdk wherever possible. So I'm moving the protocol params parsing and eip-7685 requests population to SeismicBlockExecutor's finish function. This way we can just call the non-forked EthereumBlockExecutor's finish function, and then do our stuff after, keeping them separate.

Also noticed a divergence from the eip-7685 logic in our previous placement. https://eips.ethereum.org/EIPS/eip-7685#ordering says that requests should be ordered by their type ID. Our protocol params requestID is 255, so it should be at the end of the requests after all the ethereum ones, but previously we had them after request types 0. So our requests were numbered 0,255,1,2, instead of being ordered like they are now.

This whole refactor is purely internal and doesn't affect any external APIs.

## Discussion

We could argue as to whether we prefer this "sdk" approach or the previous fork approach. One big advantage of this approach is that my goal would be to completely get rid of this fork. If we can move everything to the seismic-evm crate in here, then we could just pop that out of here and into the monorepo (close to where our non-forked reth sdk binary would eventually live).

One pro of the fork approach is that it forces us, when doing rebases of upstream code, to see new changes that conflict with our changes. This could lead to us noticing a problem with a new ethereum hardfork feature if it conflicts with our code... but, it's not a perfect solution anyways as some code could get in anyways without causing conflicts, so we would anyways need to think about the semantics of new hardfork features before merging.