### PR TITLE
ci: run CI on audit branch and fix formatting

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -2,9 +2,9 @@ name: Seismic CI
 
 on:
   push:
-    branches: [seismic]
+    branches: [seismic, veridise-audit-feb-2026]
   pull_request:
-    branches: [seismic]
+    branches: [seismic, veridise-audit-feb-2026]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -481,10 +481,7 @@ mod tests {
         let recovered = Recovered::new_unchecked(&tx_envelope, setup.signer);
 
         let result = executor.execute_transaction(recovered);
-        assert!(
-            result.is_err(),
-            "expired transaction should be rejected, but it was accepted"
-        );
+        assert!(result.is_err(), "expired transaction should be rejected, but it was accepted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `veridise-audit-feb-2026` to CI trigger branches in `seismic.yml`
- Fix cargo fmt issue in seismic block executor tests

## Test plan
- CI should trigger on PRs targeting `veridise-audit-feb-2026`
- `cargo fmt --all --check` passes