### PR TITLE
fix(block): convert timestamp to seconds for Prague activation check

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -315,3 +315,75 @@ where
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::eth::spec::EthSpec;
+    use alloy_hardforks::EthereumHardforks;
+    use alloy_primitives::U256;
+
+    // Prague activates at 1_746_612_311 seconds on mainnet.
+    const MAINNET_PRAGUE_TIMESTAMP: u64 = 1_746_612_311;
+
+    /// Replicates the Prague activation check in `EthBlockExecutor::finish`.
+    ///
+    /// BUG: When `timestamp-in-seconds` is disabled, block timestamps are in
+    /// milliseconds but `finish` passes them directly without converting to
+    /// seconds first.
+    fn finish_prague_check(spec: &EthSpec, block_timestamp: U256) -> bool {
+        spec.is_prague_active_at_timestamp(block_timestamp.saturating_to())
+    }
+
+    /// A pre-Prague millisecond timestamp must not trigger Prague activation.
+    ///
+    /// This test exercises the timestamp conversion that `finish` should apply.
+    /// Before the fix, `finish` passes raw milliseconds to `is_prague_active_at_timestamp`,
+    /// causing a pre-Prague block to incorrectly appear as post-Prague.
+    #[test]
+    fn test_finish_prague_gate_pre_prague_millis() {
+        let spec = EthSpec::mainnet();
+
+        // 1 second before Prague in seconds, expressed as milliseconds
+        let pre_prague_millis = U256::from((MAINNET_PRAGUE_TIMESTAMP - 1) * 1000);
+
+        // The Prague gate must report NOT active for a pre-Prague timestamp
+        assert!(
+            !finish_prague_check(&spec, pre_prague_millis),
+            "pre-Prague millisecond timestamp should not trigger Prague activation"
+        );
+    }
+
+    /// A post-Prague millisecond timestamp must correctly trigger Prague activation.
+    #[test]
+    fn test_finish_prague_gate_post_prague_millis() {
+        let spec = EthSpec::mainnet();
+
+        // 1 second after Prague in seconds, expressed as milliseconds
+        let post_prague_millis = U256::from((MAINNET_PRAGUE_TIMESTAMP + 1) * 1000);
+
+        assert!(
+            finish_prague_check(&spec, post_prague_millis),
+            "post-Prague millisecond timestamp should trigger Prague activation"
+        );
+    }
+
+    /// The Prague gate must transition exactly at the boundary.
+    #[test]
+    fn test_finish_prague_gate_boundary_millis() {
+        let spec = EthSpec::mainnet();
+
+        // Exactly at Prague activation (in milliseconds)
+        let at_prague_millis = U256::from(MAINNET_PRAGUE_TIMESTAMP * 1000);
+        assert!(
+            finish_prague_check(&spec, at_prague_millis),
+            "timestamp exactly at Prague boundary should be Prague-active"
+        );
+
+        // 1ms before Prague activation boundary (rounds down to pre-Prague second)
+        let just_before_millis = U256::from(MAINNET_PRAGUE_TIMESTAMP * 1000 - 1);
+        assert!(
+            !finish_prague_check(&spec, just_before_millis),
+            "1ms before Prague boundary should be pre-Prague"
+        );
+    }
+}

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -157,10 +157,15 @@ where
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
-        let requests = if self
-            .spec
-            .is_prague_active_at_timestamp(self.evm.block().timestamp.saturating_to())
-        {
+        // EVM block timestamp is in milliseconds when timestamp-in-seconds feature is disabled
+        // Fork activation checks always use seconds
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") {
+            self.evm.block().timestamp.saturating_to()
+        } else {
+            self.evm.block().timestamp.saturating_to::<u64>() / 1000
+        };
+
+        let requests = if self.spec.is_prague_active_at_timestamp(timestamp_seconds) {
             // Collect all EIP-6110 deposits
             let deposit_requests =
                 eip6110::parse_deposits_from_receipts(&self.spec, &self.receipts)?;
@@ -327,11 +332,15 @@ mod tests {
 
     /// Replicates the Prague activation check in `EthBlockExecutor::finish`.
     ///
-    /// BUG: When `timestamp-in-seconds` is disabled, block timestamps are in
-    /// milliseconds but `finish` passes them directly without converting to
-    /// seconds first.
+    /// This mirrors the code path in `finish` which converts millisecond timestamps
+    /// to seconds before checking fork activation.
     fn finish_prague_check(spec: &EthSpec, block_timestamp: U256) -> bool {
-        spec.is_prague_active_at_timestamp(block_timestamp.saturating_to())
+        let timestamp_seconds: u64 = if cfg!(feature = "timestamp-in-seconds") {
+            block_timestamp.saturating_to()
+        } else {
+            block_timestamp.saturating_to::<u64>() / 1000
+        };
+        spec.is_prague_active_at_timestamp(timestamp_seconds)
     }
 
     /// A pre-Prague millisecond timestamp must not trigger Prague activation.


### PR DESCRIPTION
## Summary
- Fix `EthBlockExecutor::finish` passing raw millisecond timestamps to `is_prague_active_at_timestamp` when `timestamp-in-seconds` is disabled
- Apply the same ms→s conversion pattern used by `eip2935.rs` and `eip4788.rs`
- Without the fix, Prague request collection (EIP-6110 deposits + protocol params) activates prematurely because the millisecond value exceeds the seconds-based fork threshold

## Test plan
- [x] Added 3 unit tests that replicate the `finish` Prague gate logic with millisecond timestamps
- [x] Tests fail before the fix (pre-Prague ms timestamps incorrectly trigger Prague)
- [x] Tests pass after the fix
- [x] Full test suite passes
- [x] `cargo fmt` and `cargo check -D warnings` clean