### PR TITLE
chore: bump seismic-revm dep which got rid of SeismicHaltReason

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,9 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "07d9df07bdcd03ccbf98fb8d1282aa19e7760a71" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "07d9df07bdcd03ccbf98fb8d1282aa19e7760a71" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "07d9df07bdcd03ccbf98fb8d1282aa19e7760a71" }
+# Pointing to the latest commit on the veridise-audit-fev-2026 branch
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
 
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy.git", tag = "v1.1.0" }

--- a/crates/seismic-evm/src/lib.rs
+++ b/crates/seismic-evm/src/lib.rs
@@ -13,7 +13,7 @@ use core::ops::{Deref, DerefMut};
 use revm::{
     context::{result::InvalidTransaction, BlockEnv, TxEnv},
     context_interface::{
-        result::{EVMError, ResultAndState},
+        result::{EVMError, HaltReason, ResultAndState},
         ContextTr,
     },
     database_interface::EmptyDB,
@@ -26,7 +26,7 @@ use seismic_revm::{
     instructions::instruction_provider::SeismicInstructions,
     precompiles::SeismicPrecompiles,
     transaction::abstraction::{RngMode, SeismicTransaction},
-    DefaultSeismicContext, SeismicBuilder, SeismicContext, SeismicHaltReason, SeismicSpecId,
+    DefaultSeismicContext, SeismicBuilder, SeismicContext, SeismicSpecId,
 };
 
 pub mod block;
@@ -110,7 +110,7 @@ where
     type DB = DB;
     type Tx = SeismicTransaction<TxEnv>;
     type Error = EVMError<DB::Error>;
-    type HaltReason = SeismicHaltReason;
+    type HaltReason = HaltReason;
     type Spec = SeismicSpecId;
     type Precompiles = P;
     type Inspector = I;
@@ -322,7 +322,7 @@ impl EvmFactory for SeismicEvmFactory {
     type Tx = SeismicTransaction<TxEnv>;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
         EVMError<DBError, InvalidTransaction>;
-    type HaltReason = SeismicHaltReason;
+    type HaltReason = HaltReason;
     type Spec = SeismicSpecId;
     type Precompiles<DB: Database> = SeismicPrecompiles<Self::Context<DB>>;
 


### PR DESCRIPTION
Halt was changed to a revert, so we no longer need SeismicHaltReason. 
See https://github.com/SeismicSystems/seismic-revm/pull/210