### PR TITLE
feat(rng): add parent_block_hash and tx_hash_accumulator to RNG domain data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,9 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "2ad2e5893ba8a6af45806ea09df58e5c00bdf16d" }
 
 # revm
-# Pointing to the latest commit on the veridise-audit-feb-2026 branch
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e2915bad927dc3e6239498716241ed41ea91de4c" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e2915bad927dc3e6239498716241ed41ea91de4c" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e2915bad927dc3e6239498716241ed41ea91de4c" }
+# Pointing to https://github.com/SeismicSystems/seismic-revm/pull/215
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
 
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy.git", tag = "v1.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,9 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "2ad2e5893ba8a6af45806ea09df58e5c00bdf16d" }
 
 # revm
-# Pointing to https://github.com/SeismicSystems/seismic-revm/pull/215
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d9848849507eeab70768165c433d70578daabfd0" }
+# Pointing to https://github.com/SeismicSystems/seismic-revm/pull/189
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ced04afaddfb7193f6f7b2b5033244435549c866" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ced04afaddfb7193f6f7b2b5033244435549c866" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ced04afaddfb7193f6f7b2b5033244435549c866" }
 
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy.git", tag = "v1.1.0" }

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -20,7 +20,7 @@ use alloy_eips::{
 use alloy_primitives::{Address, Bytes, TxKind};
 use revm::{context::TxEnv, context_interface::either::Either};
 use seismic_alloy_consensus::{SeismicTxEnvelope, SEISMIC_TX_TYPE_ID};
-use seismic_revm::{transaction::abstraction::RngMode, SeismicTransaction};
+use seismic_revm::SeismicTransaction;
 
 /// Trait marking types that can be converted into a transaction environment.
 ///
@@ -553,12 +553,7 @@ impl FromTxWithEncoded<SeismicTxEnvelope> for SeismicTransaction<TxEnv> {
     fn from_encoded_tx(tx: &SeismicTxEnvelope, sender: Address, _encoded: Bytes) -> Self {
         let tx_env = SeismicTransaction::<TxEnv>::from_recovered_tx(tx, sender);
 
-        Self {
-            base: tx_env.base,
-            tx_hash: tx_env.tx_hash,
-            rng_mode: RngMode::Execution,
-            decryption_failed: false,
-        }
+        Self { base: tx_env.base, tx_hash: tx_env.tx_hash, decryption_failed: false }
     }
 }
 
@@ -567,10 +562,6 @@ impl FromTxWithEncoded<SeismicTxEnvelope> for SeismicTransaction<TxEnv> {
 /// Necessary to include in this crate due to the orphan rule.
 impl FromRecoveredTx<SeismicTxEnvelope> for SeismicTransaction<TxEnv> {
     fn from_recovered_tx(tx: &SeismicTxEnvelope, sender: Address) -> Self {
-        // TODO: this should not be hardcoded
-        // Ok for now because we only use this for testing
-        let rng_mode = RngMode::Execution;
-
         let tx_hash = tx.tx_hash().clone();
         let base = match tx {
             SeismicTxEnvelope::Legacy(tx) => TxEnv {
@@ -670,7 +661,7 @@ impl FromRecoveredTx<SeismicTxEnvelope> for SeismicTransaction<TxEnv> {
                 authorization_list: vec![],
             },
         };
-        SeismicTransaction { base, tx_hash, rng_mode, decryption_failed: false }
+        SeismicTransaction { base, tx_hash, decryption_failed: false }
     }
 }
 

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -27,9 +27,26 @@ use alloy_evm::{
     FromTxWithEncoded, RecoveredTx, ToTxEnv,
 };
 use alloy_primitives::{Bytes, U256};
-use revm::context::{result::ExecutionResult, TxEnv};
+use revm::{
+    context::{result::ExecutionResult, TxEnv},
+    context_interface::ContextTr,
+};
 use seismic_alloy_consensus::InputDecryptionElements;
-use seismic_revm::transaction::abstraction::SeismicTransaction;
+use seismic_revm::{transaction::abstraction::SeismicTransaction, SeismicChain};
+
+/// Trait for accessing the SeismicChain from within a generic EVM context.
+/// Implemented by [`crate::SeismicEvm`] to allow the block executor to set
+/// RNG domain data (parent_block_hash, tx_hash_accumulator).
+pub trait SeismicChainAccess {
+    /// Returns a mutable reference to the [`SeismicChain`].
+    fn seismic_chain_mut(&mut self) -> &mut SeismicChain;
+}
+
+impl<DB: Database, I, P> SeismicChainAccess for crate::SeismicEvm<DB, I, P> {
+    fn seismic_chain_mut(&mut self) -> &mut SeismicChain {
+        self.ctx_mut().chain_mut()
+    }
+}
 
 type SeismicBlockExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
 
@@ -104,8 +121,10 @@ where
 impl<'db, DB, E, Spec, R> BlockExecutor for SeismicBlockExecutor<'_, E, Spec, R>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>>,
-    SeismicTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    E: Evm<
+            DB = &'db mut State<DB>,
+            Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+        > + SeismicChainAccess,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<
         Transaction: Transaction + Encodable2718 + InputDecryptionElements + Clone,
@@ -117,6 +136,8 @@ where
     type Evm = E;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        let parent_hash = self.inner.ctx.parent_hash;
+        self.evm_mut().seismic_chain_mut().set_parent_block_hash(parent_hash);
         self.inner.apply_pre_execution_changes()
     }
 
@@ -131,11 +152,13 @@ where
             .validate_block(current_block, &[self.inner.ctx.parent_hash])
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
+        let tx_hash = receipt_tx.trie_hash();
+
         let signer = RecoveredTx::signer(&tx);
-        match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
+        let result = match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
             Ok(plaintext_base) => {
                 let recovered = Recovered::new_unchecked(plaintext_base, *signer);
-                self.inner.execute_transaction_with_commit_condition(&recovered, f)
+                self.inner.execute_transaction_with_commit_condition(&recovered, f)?
             }
             Err(_) => {
                 // Decryption failed: zero the calldata so intrinsic gas is only
@@ -146,9 +169,15 @@ where
                 let _ = failed_tx.set_input(Bytes::new());
                 let recovered = Recovered::new_unchecked(failed_tx, *signer);
                 self.inner
-                    .execute_transaction_with_commit_condition(DecryptionFailed(&recovered), f)
+                    .execute_transaction_with_commit_condition(DecryptionFailed(&recovered), f)?
             }
+        };
+
+        // Advance the tx hash accumulator only if the transaction was committed.
+        if result.is_some() {
+            self.evm_mut().seismic_chain_mut().advance_tx_accumulator(&tx_hash);
         }
+        Ok(result)
     }
 
     fn execute_transaction_with_result_closure(
@@ -162,19 +191,26 @@ where
             .validate_block(current_block, &[self.inner.ctx.parent_hash])
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
+        let tx_hash = receipt_tx.trie_hash();
+
         let signer = RecoveredTx::signer(&tx);
-        match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
+        let result = match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
             Ok(plaintext_base) => {
                 let recovered = Recovered::new_unchecked(plaintext_base, *signer);
-                self.inner.execute_transaction_with_result_closure(&recovered, f)
+                self.inner.execute_transaction_with_result_closure(&recovered, f)?
             }
             Err(_) => {
                 let mut failed_tx = receipt_tx.clone();
                 let _ = failed_tx.set_input(Bytes::new());
                 let recovered = Recovered::new_unchecked(failed_tx, *signer);
-                self.inner.execute_transaction_with_result_closure(DecryptionFailed(&recovered), f)
+                self.inner
+                    .execute_transaction_with_result_closure(DecryptionFailed(&recovered), f)?
             }
-        }
+        };
+
+        // Always advance accumulator (this path always commits).
+        self.evm_mut().seismic_chain_mut().advance_tx_accumulator(&tx_hash);
+        Ok(result)
     }
 
     fn finish(self) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
@@ -239,18 +275,17 @@ impl<R, Spec, EvmFactory> SeismicBlockExecutorFactory<R, Spec, EvmFactory> {
     }
 }
 
-impl<R, Spec, EvmF> BlockExecutorFactory for SeismicBlockExecutorFactory<R, Spec, EvmF>
+impl<R, Spec> BlockExecutorFactory for SeismicBlockExecutorFactory<R, Spec, SeismicEvmFactory>
 where
     R: ReceiptBuilder<
         Transaction: Transaction + Encodable2718 + InputDecryptionElements + Clone,
         Receipt: TxReceipt<Log = Log>,
     >,
     Spec: SeismicHardforks + EthExecutorSpec,
-    EvmF: EvmFactory<Tx = SeismicTransaction<TxEnv>>,
     SeismicTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Self: 'static,
 {
-    type EvmFactory = EvmF;
+    type EvmFactory = SeismicEvmFactory;
     type ExecutionCtx<'a> = SeismicBlockExecutionCtx<'a>;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
@@ -259,16 +294,14 @@ where
         &self.evm_factory
     }
 
-    // <EvmF as EvmFactory>::Tx: RecoveredTx<<R as ReceiptBuilder>::Transaction>`
-
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: EvmF::Evm<&'a mut State<DB>, I>,
+        evm: <SeismicEvmFactory as EvmFactory>::Evm<&'a mut State<DB>, I>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: Database + 'a,
-        I: Inspector<EvmF::Context<&'a mut State<DB>>> + 'a,
+        I: Inspector<<SeismicEvmFactory as EvmFactory>::Context<&'a mut State<DB>>> + 'a,
     {
         SeismicBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder, self.purpose_keys)
     }

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -121,10 +121,8 @@ where
 impl<'db, DB, E, Spec, R> BlockExecutor for SeismicBlockExecutor<'_, E, Spec, R>
 where
     DB: Database + 'db,
-    E: Evm<
-            DB = &'db mut State<DB>,
-            Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
-        > + SeismicChainAccess,
+    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>> + SeismicChainAccess,
+    SeismicTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<
         Transaction: Transaction + Encodable2718 + InputDecryptionElements + Clone,

--- a/crates/seismic-evm/src/lib.rs
+++ b/crates/seismic-evm/src/lib.rs
@@ -23,10 +23,9 @@ use revm::{
     Context, ExecuteEvm, InspectEvm, Inspector,
 };
 use seismic_revm::{
-    instructions::instruction_provider::SeismicInstructions,
-    precompiles::SeismicPrecompiles,
-    transaction::abstraction::{RngMode, SeismicTransaction},
-    DefaultSeismicContext, SeismicBuilder, SeismicContext, SeismicSpecId,
+    instructions::instruction_provider::SeismicInstructions, precompiles::SeismicPrecompiles,
+    transaction::abstraction::SeismicTransaction, DefaultSeismicContext, SeismicBuilder,
+    SeismicContext, SeismicSpecId,
 };
 
 pub mod block;
@@ -173,7 +172,6 @@ where
                 authorization_list: Default::default(),
             },
             tx_hash: Default::default(),
-            rng_mode: RngMode::Execution,
             decryption_failed: false,
         };
 


### PR DESCRIPTION
Uses https://github.com/SeismicSystems/seismic-revm/pull/215

Addresses Veridise audit findings V-SEISMIC-VUL-002 (cross-fork replay) and V-SEISMIC-VUL-004 (proposer bias) by binding RNG output to block context and transaction history.

The SeismicBlockExecutor now:
- Sets parent_block_hash on SeismicChain in apply_pre_execution_changes
- Advances a tx_hash_accumulator (keccak chain) after each committed tx

Both fields flow into the HKDF info parameter, ensuring identical transactions on different forks or at different positions in a block produce different RNG output.

Also removes stale RngMode references (removed in seismic-revm) and makes BlockExecutorFactory impl concrete over SeismicEvmFactory to support the SeismicChainAccess trait bound.