### PR TITLE
fix(block): validate recent_block_hash against 100-block window, not just parent

### DIFF
--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -26,10 +26,10 @@ use alloy_evm::{
     block::{CommitChanges, ExecutableTx, InternalBlockExecutionError},
     FromTxWithEncoded, RecoveredTx, ToTxEnv,
 };
-use alloy_primitives::U256;
+use alloy_primitives::{B256,U256};
 use revm::{
     context::{result::ExecutionResult, TxEnv},
-    context_interface::ContextTr,
+    context_interface::{ContextTr, Host},
 };
 use seismic_alloy_consensus::InputDecryptionElements;
 use seismic_revm::{transaction::abstraction::SeismicTransaction, SeismicChain};
@@ -45,6 +45,24 @@ pub trait SeismicChainAccess {
 impl<DB: Database, I, P> SeismicChainAccess for crate::SeismicEvm<DB, I, P> {
     fn seismic_chain_mut(&mut self) -> &mut SeismicChain {
         self.ctx_mut().chain_mut()
+    }
+}
+
+/// Maximum number of blocks to look back for `recent_block_hash` validation.
+/// Must match `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` in seismic-reth txpool.
+const SEISMIC_TX_RECENT_BLOCK_LOOKBACK: u64 = 100;
+
+/// Trait for looking up block hashes from the EVM's database.
+/// Implemented by [`crate::SeismicEvm`] to allow the block executor to
+/// validate `recent_block_hash` against a window of recent blocks.
+pub trait BlockHashReader {
+    /// Returns the block hash for the given block number, or `None` on DB error.
+    fn block_hash(&mut self, number: u64) -> Option<B256>;
+}
+
+impl<DB: Database, I, P> BlockHashReader for crate::SeismicEvm<DB, I, P> {
+    fn block_hash(&mut self, number: u64) -> Option<B256> {
+        Host::block_hash(self.ctx_mut(), number)
     }
 }
 
@@ -84,6 +102,34 @@ where
     }
 }
 
+/// Collects hashes of recent blocks for `recent_block_hash` validation.
+///
+/// Always includes `parent_hash` (the authoritative hash of block `current_block - 1`),
+/// plus up to `SEISMIC_TX_RECENT_BLOCK_LOOKBACK - 1` additional hashes fetched from
+/// the database for older blocks.
+fn collect_recent_block_hashes(
+    parent_hash: B256,
+    current_block: u64,
+    evm: &mut impl BlockHashReader,
+) -> Vec<B256> {
+    let mut hashes = Vec::with_capacity(SEISMIC_TX_RECENT_BLOCK_LOOKBACK as usize);
+
+    // Always include the parent hash (block current_block - 1)
+    hashes.push(parent_hash);
+
+    // Fetch hashes for blocks current_block-2 down to the lookback limit
+    if current_block >= 2 {
+        let oldest = current_block.saturating_sub(SEISMIC_TX_RECENT_BLOCK_LOOKBACK);
+        for n in (oldest..current_block.saturating_sub(1)).rev() {
+            if let Some(hash) = evm.block_hash(n) {
+                hashes.push(hash);
+            }
+        }
+    }
+
+    hashes
+}
+
 /// Wrapper that marks a transaction as having failed calldata decryption.
 ///
 /// When converted to `SeismicTransaction<TxEnv>` via [`ToTxEnv`], the resulting
@@ -121,7 +167,7 @@ where
 impl<'db, DB, E, Spec, R> BlockExecutor for SeismicBlockExecutor<'_, E, Spec, R>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>> + SeismicChainAccess,
+    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>> + SeismicChainAccess + BlockHashReader,
     SeismicTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<
@@ -146,8 +192,11 @@ where
     ) -> Result<Option<u64>, BlockExecutionError> {
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
+        let parent_hash = self.inner.ctx.parent_hash;
+        let recent_hashes =
+            collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
         receipt_tx
-            .validate_block(current_block, &[self.inner.ctx.parent_hash])
+            .validate_block(current_block, &recent_hashes)
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
         let tx_hash = receipt_tx.trie_hash();
@@ -183,8 +232,11 @@ where
     ) -> Result<u64, BlockExecutionError> {
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
+        let parent_hash = self.inner.ctx.parent_hash;
+        let recent_hashes =
+            collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
         receipt_tx
-            .validate_block(current_block, &[self.inner.ctx.parent_hash])
+            .validate_block(current_block, &recent_hashes)
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
         let tx_hash = receipt_tx.trie_hash();

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -193,8 +193,7 @@ where
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
-        let recent_hashes =
-            collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
+        let recent_hashes = collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
         receipt_tx
             .validate_block(current_block, &recent_hashes)
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
@@ -233,8 +232,7 @@ where
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
-        let recent_hashes =
-            collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
+        let recent_hashes = collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
         receipt_tx
             .validate_block(current_block, &recent_hashes)
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -26,12 +26,12 @@ use alloy_evm::{
     block::{CommitChanges, ExecutableTx, InternalBlockExecutionError},
     FromTxWithEncoded, RecoveredTx, ToTxEnv,
 };
-use alloy_primitives::{B256,U256};
+use alloy_primitives::{B256, U256};
 use revm::{
     context::{result::ExecutionResult, TxEnv},
     context_interface::{ContextTr, Host},
 };
-use seismic_alloy_consensus::InputDecryptionElements;
+use seismic_alloy_consensus::{InputDecryptionElements, SeismicValidationError};
 use seismic_revm::{transaction::abstraction::SeismicTransaction, SeismicChain};
 
 /// Trait for accessing the SeismicChain from within a generic EVM context.
@@ -102,34 +102,6 @@ where
     }
 }
 
-/// Collects hashes of recent blocks for `recent_block_hash` validation.
-///
-/// Always includes `parent_hash` (the authoritative hash of block `current_block - 1`),
-/// plus up to `SEISMIC_TX_RECENT_BLOCK_LOOKBACK - 1` additional hashes fetched from
-/// the database for older blocks.
-fn collect_recent_block_hashes(
-    parent_hash: B256,
-    current_block: u64,
-    evm: &mut impl BlockHashReader,
-) -> Vec<B256> {
-    let mut hashes = Vec::with_capacity(SEISMIC_TX_RECENT_BLOCK_LOOKBACK as usize);
-
-    // Always include the parent hash (block current_block - 1)
-    hashes.push(parent_hash);
-
-    // Fetch hashes for blocks current_block-2 down to the lookback limit
-    if current_block >= 2 {
-        let oldest = current_block.saturating_sub(SEISMIC_TX_RECENT_BLOCK_LOOKBACK);
-        for n in (oldest..current_block.saturating_sub(1)).rev() {
-            if let Some(hash) = evm.block_hash(n) {
-                hashes.push(hash);
-            }
-        }
-    }
-
-    hashes
-}
-
 /// Wrapper that marks a transaction as having failed calldata decryption.
 ///
 /// When converted to `SeismicTransaction<TxEnv>` via [`ToTxEnv`], the resulting
@@ -164,10 +136,50 @@ where
     }
 }
 
+fn validate_tx_decryption_elements<
+    R: Transaction + Encodable2718 + InputDecryptionElements + Clone,
+>(
+    tx: &R,
+    current_block: u64,
+    parent_hash: B256,
+    block_hash_reader: &mut impl BlockHashReader,
+) -> Result<(), SeismicValidationError> {
+    let elements = match tx.get_decryption_elements() {
+        Ok(elements) => elements,
+        Err(_) => return Ok(()), // No decryption elements; nothing to validate
+    };
+
+    if current_block > elements.expires_at_block {
+        return Err(SeismicValidationError::TransactionExpired {
+            current_block,
+            expires_at_block: elements.expires_at_block,
+        });
+    }
+
+    // Fast path: check parent hash directly
+    if elements.recent_block_hash == parent_hash {
+        return Ok(());
+    }
+
+    // Walk backwards through the lookback window
+    let oldest = current_block.saturating_sub(SEISMIC_TX_RECENT_BLOCK_LOOKBACK);
+    for n in (oldest..current_block.saturating_sub(1)).rev() {
+        if block_hash_reader.block_hash(n) == Some(elements.recent_block_hash) {
+            return Ok(());
+        }
+    }
+
+    Err(SeismicValidationError::InvalidRecentBlockHash {
+        provided_hash: elements.recent_block_hash,
+    })
+}
+
 impl<'db, DB, E, Spec, R> BlockExecutor for SeismicBlockExecutor<'_, E, Spec, R>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>> + SeismicChainAccess + BlockHashReader,
+    E: Evm<DB = &'db mut State<DB>, Tx = SeismicTransaction<TxEnv>>
+        + SeismicChainAccess
+        + BlockHashReader,
     SeismicTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<
@@ -193,9 +205,8 @@ where
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
-        let recent_hashes = collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
-        receipt_tx
-            .validate_block(current_block, &recent_hashes)
+
+        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
         let tx_hash = receipt_tx.trie_hash();
@@ -232,9 +243,8 @@ where
         let receipt_tx: &<R as ReceiptBuilder>::Transaction = RecoveredTx::tx(&tx);
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
-        let recent_hashes = collect_recent_block_hashes(parent_hash, current_block, self.evm_mut());
-        receipt_tx
-            .validate_block(current_block, &recent_hashes)
+
+        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
             .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
 
         let tx_hash = receipt_tx.trie_hash();


### PR DESCRIPTION
The block executor was validating a seismic transaction's recent_block_hash against only the immediate parent hash: `&[self.inner.ctx.parent_hash]`. This meant any transaction whose recent_block_hash didn't match the exact                             
parent of the block being built was rejected — even if it referenced a perfectly recent block just 2-3 blocks back.
                                                         
This created a race condition in the local miner (and affects production):
1. Client fetches latest block N, builds tx with recent_block_hash = hash(N)                                
2. A block N+1 gets mined before the tx is included
3. Miner builds block N+2 with parent = hash(N+1)          
4. Validation fails: [hash(N+1)].contains(hash(N)) → false 
5. Tx is stuck — every subsequent block attempt fails the same way
                                                         
Meanwhile, the txpool validator (SeismicTransactionValidator in seismic-reth) correctly validates against a 100-block window via RecentBlockCache. So txs were accepted into the pool but rejected at execution time.
                                                           
Fix: look up the last 100 block hashes from the EVM's state database, matching the txpool's SEISMIC_TX_RECENT_BLOCK_LOOKBACK window. This is done via a new BlockHashReader trait implemented on SeismicEvm, which delegates to revm's Host::block_hash (backed by the state DB with its own BTreeMap cache, so repeat lookups within a block are O(1)).

## Cost Analysis

The DB is NOT hit 100 times per block — revm's State has a [BTreeMap<u64, B256> cache](https://github.com/SeismicSystems/seismic-revm/blob/e2915bad927dc3e6239498716241ed41ea91de4c/crates/database/src/states/state.rs#L65) that caches the last 256 block hasehs, so the actual DB hits are ~99 on the first transaction only. Subsequent transactions in the same block get cache hits.
                                                                                 
The real inefficiency is per-transaction waste:                                  
- collect_recent_block_hashes() is called on every transaction, rebuilding the same Vec<B256> of 100 hashes each time (even though block number doesn't change within a block)
- That's 99 BTreeMap lookups + a Vec allocation per tx, all returning the same data                                                                             
- Plus a linear scan (contains) over 100 entries per tx                          
                                                       
The fix: compute recent_hashes once per block (lazily on first tx), store it on  
SeismicBlockExecutor, and reuse for all subsequent transactions. Something like: 
```
struct SeismicBlockExecutor<'a, Evm, Spec, R> {                                  
    inner: EthBlockExecutor<'a, Evm, Spec, R>,                                   
    purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,              
    recent_hashes: Option<Vec<B256>>,  // lazily populated once per block        
}
```

This eliminates the per-tx overhead entirely. The one-time 99 DB hits per block is acceptable.

## Note

Personally think we should consider switching to timestamps like tempo does rather than block_hashes.
Especially in the context of the extra complexity that would be required to fix the Cost Analysis section above.