### PR TITLE
fix(overrides): disallow storage overrides on Seismic

### DIFF
--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -4,7 +4,7 @@
 //! - Block and state overrides
 
 use alloc::collections::BTreeMap;
-use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
+use alloy_primitives::{map::HashMap, Address, B256, U256};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
     BlockOverrides,
@@ -13,7 +13,7 @@ use revm::{
     bytecode::BytecodeDecodeError,
     context::BlockEnv,
     database::{CacheDB, State},
-    state::{Account, AccountStatus, Bytecode, EvmStorageSlot},
+    state::{Account, AccountStatus, EvmStorageSlot},
     Database, DatabaseCommit,
 };
 
@@ -29,6 +29,9 @@ pub enum StateOverrideError<E> {
     /// Code overrides are not permitted (Seismic privacy).
     #[error("Code overrides are not permitted on Seismic (account: {0})")]
     CodeOverrideNotPermitted(Address),
+    /// Storage overrides (state/stateDiff) are not permitted (Seismic privacy).
+    #[error("Storage overrides are not permitted on Seismic (account: {0})")]
+    StorageOverrideNotPermitted(Address),
     /// Database error occurred.
     #[error(transparent)]
     Database(E),
@@ -138,6 +141,9 @@ where
     }
     if account_override.code.is_some() {
         return Err(StateOverrideError::CodeOverrideNotPermitted(account));
+    }
+    if account_override.state.is_some() || account_override.state_diff.is_some() {
+        return Err(StateOverrideError::StorageOverrideNotPermitted(account));
     }
     if let Some(balance) = account_override.balance {
         info.balance = balance;

--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -234,56 +234,36 @@ mod tests {
     }
 
     #[test]
-    fn test_state_override_storage() {
+    fn test_state_diff_override_rejected_cache_db() {
         let account = address!("0x1234567890123456789012345678901234567890");
-        let slot1 = B256::from(U256::from(1));
-        let slot2 = B256::from(U256::from(2));
-        let value1 = B256::from(U256::from(100));
-        let value2 = B256::from(U256::from(200));
+        let slot = B256::from(U256::from(1));
+        let value = B256::from(U256::from(100));
 
         let mut db = CacheDB::new(EmptyDB::new());
 
-        // Create storage overrides
         let mut storage = HashMap::<B256, B256>::default();
-        storage.insert(slot1, value1);
-        storage.insert(slot2, value2);
+        storage.insert(slot, value);
 
         let acc_override = AccountOverride::default().with_state_diff(storage);
-        apply_account_override(account, acc_override, &mut db).unwrap();
-
-        // Get the storage value using the database interface
-        let storage1 = db.storage(account, U256::from(1)).unwrap();
-        let storage2 = db.storage(account, U256::from(2)).unwrap();
-
-        assert_eq!(storage1, U256::from(100).into());
-        assert_eq!(storage2, U256::from(200).into());
+        let result = apply_account_override(account, acc_override, &mut db);
+        assert!(result.is_err(), "state_diff overrides should be rejected");
     }
 
     #[test]
-    fn test_state_override_full_state() {
+    fn test_state_override_rejected_state_db() {
         let account = address!("0x1234567890123456789012345678901234567890");
-        let slot1 = B256::from(U256::from(1));
-        let slot2 = B256::from(U256::from(2));
-        let value1 = B256::from(U256::from(100));
-        let value2 = B256::from(U256::from(200));
+        let slot = B256::from(U256::from(1));
+        let value = B256::from(U256::from(100));
 
         let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
 
-        // Create storage overrides using state (not state_diff)
         let mut storage = HashMap::<B256, B256>::default();
-        storage.insert(slot1, value1);
-        storage.insert(slot2, value2);
+        storage.insert(slot, value);
 
         let acc_override = AccountOverride::default().with_state(storage);
         let mut state_overrides = StateOverride::default();
         state_overrides.insert(account, acc_override);
-        apply_state_overrides(state_overrides, &mut db).unwrap();
-
-        // Get the storage value using the database interface
-        let storage1 = db.storage(account, U256::from(1)).unwrap();
-        let storage2 = db.storage(account, U256::from(2)).unwrap();
-
-        assert_eq!(storage1, U256::from(100).into());
-        assert_eq!(storage2, U256::from(200).into());
+        let result = apply_state_overrides(state_overrides, &mut db);
+        assert!(result.is_err(), "state overrides should be rejected");
     }
 }


### PR DESCRIPTION
## Summary

Signed reads executed via `eth_call` currently permit callers to modify account storage through `state` / `stateDiff` overrides, letting an attacker evaluate a contract against attacker-controlled state and defeat the privacy guarantee that signed reads reflect authentic on-chain storage. The implementation already rejects **code** overrides for exactly this class of reason — this PR extends the same protection to **storage** overrides.

- New `StateOverrideError::StorageOverrideNotPermitted(Address)` variant.
- Early return in `apply_account_override` when `state` or `state_diff` is set — same chokepoint used by the existing code-override rejection, so the block covers every caller (`eth_call`, `eth_estimateGas`, `eth_simulateV1`, tracing / debug RPCs).
- Existing success-path tests for `state` and `stateDiff` overrides are replaced with rejection assertions.
- Drops two imports (`keccak256`, `Bytecode`) left over from the earlier code-override change — `RUSTFLAGS="-D warnings"` now flags them since the downstream code referencing them is unreachable.

## Context

Audit finding: signed reads accept arbitrary storage modifications, allowing an attacker to substitute private initialization values (e.g. a private salt used to add entropy / obscure observable behavior) with known ones and evaluate the contract under manipulated state — neutralizing the privacy benefit. Blocking universally (rather than gating on `signed_read`) matches the precedent set by the code-override fix (#45) and removes any dependency on the `from`-sanitization being watertight for unsigned calls.

## Companion PR

Requires a matching change in seismic-reth to map the new error variant through `EthApiError`.

## Test plan

- [x] `cargo test --features overrides overrides::` — 4 passed (2 code-override, 2 storage-override)
- [x] `RUSTFLAGS="-D warnings" cargo check --features overrides` — clean