### PR TITLE
fix(seismic-evm): classify stale seismic tx as InvalidTx, not Internal

### DIFF
--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -4,7 +4,8 @@ use alloc::{
     string::{String, ToString},
 };
 use alloy_primitives::B256;
-use seismic_alloy_consensus::{InputDecryptionElementsError, SeismicValidationError};
+use revm::context_interface::result::InvalidTransaction;
+use seismic_alloy_consensus::SeismicValidationError;
 
 /// Block validation error.
 #[derive(Debug, thiserror::Error)]
@@ -85,6 +86,33 @@ pub enum BlockValidationError {
     ProtocolParamRequestDecode(String),
 }
 
+/// Routes a Seismic freshness failure (a stale or expired tx) through alloy-evm's standard
+/// invalid-transaction path rather than treating it as a fatal executor error.
+///
+/// A freshness failure is a *per-transaction* validity problem — the rest of the block is
+/// unaffected — so it belongs in [`BlockValidationError::InvalidTx`], like a bad nonce or
+/// insufficient funds. That classification drives both consumers of execution errors correctly:
+/// - when *proposing* a block, the payload builder skips the offending tx and keeps building (one
+///   stale tx must not abort the whole block);
+/// - when *validating* a block received from a peer (consensus block execution, i.e. `newPayload`),
+///   the engine responds `INVALID` and rejects the block, instead of treating it as an internal
+///   node fault.
+impl InvalidTxError for SeismicValidationError {
+    /// `false`: a freshness failure is unrelated to the nonce. The builder reads this flag only to
+    /// decide whether to keep the sender's later txs; returning `false` makes it drop them, which
+    /// is correct — a skipped tx leaves a nonce gap, so its descendants can't execute anyway.
+    fn is_nonce_too_low(&self) -> bool {
+        false
+    }
+
+    /// `None`: this is a Seismic-specific validity rule with no underlying revm
+    /// [`InvalidTransaction`]. The value is only consulted to enrich error conversion (e.g. RPC
+    /// responses), which falls back to this error's `Display` when it is `None`.
+    fn as_invalid_tx_err(&self) -> Option<&InvalidTransaction> {
+        None
+    }
+}
+
 /// `BlockExecutor` Errors
 #[derive(Debug, thiserror::Error)]
 pub enum BlockExecutionError {
@@ -149,12 +177,6 @@ pub enum InternalBlockExecutionError {
         /// The EVM error.
         error: Box<dyn core::error::Error + Send + Sync>,
     },
-    /// Unable to decrypt calldata of seismic tx
-    #[error("Failed to decrypt seismic tx: {0}")]
-    FailedToDecryptSeismicTx(InputDecryptionElementsError),
-    /// Seismic transaction failed block-level validation (expiration, recent block hash)
-    #[error("Seismic tx validation failed: {0}")]
-    SeismicValidationFailed(SeismicValidationError),
     /// Arbitrary Block Executor Errors
     #[error(transparent)]
     Other(Box<dyn core::error::Error + Send + Sync + 'static>),

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -23,7 +23,7 @@ use revm::{database::State, Inspector};
 pub mod receipt_builder;
 use alloy_consensus::transaction::Recovered;
 use alloy_evm::{
-    block::{CommitChanges, ExecutableTx, InternalBlockExecutionError},
+    block::{BlockValidationError, CommitChanges, ExecutableTx},
     FromTxWithEncoded, RecoveredTx, ToTxEnv,
 };
 use alloy_primitives::{B256, U256};
@@ -206,10 +206,15 @@ where
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
 
-        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
-            .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
-
         let tx_hash = receipt_tx.trie_hash();
+
+        // Freshness failure is a per-tx validity error (the tx is stale), not a fatal internal
+        // error: surface it as InvalidTx so the builder skips it and block import responds INVALID.
+        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
+            .map_err(|error| BlockValidationError::InvalidTx {
+                hash: tx_hash,
+                error: Box::new(error),
+            })?;
 
         let signer = RecoveredTx::signer(&tx);
         let result = match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
@@ -244,10 +249,15 @@ where
         let current_block: u64 = self.evm().block().number.saturating_to();
         let parent_hash = self.inner.ctx.parent_hash;
 
-        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
-            .map_err(InternalBlockExecutionError::SeismicValidationFailed)?;
-
         let tx_hash = receipt_tx.trie_hash();
+
+        // Freshness failure is a per-tx validity error (the tx is stale), not a fatal internal
+        // error: surface it as InvalidTx so the builder skips it and block import responds INVALID.
+        validate_tx_decryption_elements(receipt_tx, current_block, parent_hash, self.evm_mut())
+            .map_err(|error| BlockValidationError::InvalidTx {
+                hash: tx_hash,
+                error: Box::new(error),
+            })?;
 
         let signer = RecoveredTx::signer(&tx);
         let result = match receipt_tx.plaintext_copy(&self.purpose_keys.tx_io_sk, *signer) {
@@ -546,6 +556,47 @@ mod tests {
         let tx_envelope = get_tx_envelope(&setup, tx_seismic);
         let recovered = Recovered::new_unchecked(&tx_envelope, setup.signer);
         executor.execute_transaction(recovered).unwrap();
+    }
+
+    /// A Seismic tx whose freshness window has passed must surface as a *validation* error
+    /// (`BlockValidationError::InvalidTx`), not a fatal `Internal` error — that classification is
+    /// what lets the payload builder skip it and block import respond INVALID.
+    #[test]
+    fn test_expired_tx_is_validation_error() {
+        let db = InMemoryDB::default();
+        let mut state = StateBuilder::new_with_database(db).build();
+        let setup = setup_test(&mut state);
+
+        // Block 100 with a tx that expired at block 50.
+        let mut block_env = BlockEnv::default();
+        block_env.number = U256::from(100);
+        let evm = setup.evm_factory.create_evm(
+            &mut state,
+            EvmEnv::new(CfgEnv::new_with_spec(SeismicSpecId::MERCURY), block_env),
+        );
+        let mut executor = setup.executor_factory.create_executor(evm, setup.ctx.clone());
+
+        let elements = TxSeismicElements {
+            encryption_pubkey: setup.encryption_pubkey,
+            encryption_nonce: U96::from_be_slice(&setup.encryption_nonce.0),
+            message_version: 0,
+            // Matches setup_test's parent_hash, so only the expiry check fails.
+            recent_block_hash: B256::ZERO,
+            expires_at_block: 50,
+            signed_read: false,
+        };
+        let tx = sample_seismic_tx_with_elements(&setup, "hello world", elements);
+        let tx_envelope = get_tx_envelope(&setup, tx);
+        let recovered = Recovered::new_unchecked(&tx_envelope, setup.signer);
+
+        let result = executor.execute_transaction(recovered);
+        assert!(
+            matches!(
+                result,
+                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }))
+            ),
+            "expired tx must be a validation (InvalidTx) error, got: {result:?}"
+        );
     }
 
     /// Decryption failure is now handled as a metered transaction failure:


### PR DESCRIPTION
A block-level freshness failure (expired tx or stale recent_block_hash) is a per-transaction validity problem, but it was surfaced as InternalBlockExecutionError::SeismicValidationFailed (added in #34) — an Internal error that consumers treat as fatal. That made the payload builder abort the whole block when a pooled tx aged out before inclusion, and made the consensus engine classify a peer's expired-tx block as a fatal node fault instead of responding INVALID.

Implement InvalidTxError for SeismicValidationError and route freshness failures through BlockValidationError::InvalidTx, so they are skipped by builders and rejected as INVALID on import like any other invalid tx. Also drop the long-dead FailedToDecryptSeismicTx variant (decrypt failures are handled inline as a charged no-op via DecryptionFailed), leaving InternalBlockExecutionError aligned with upstream. Covered by a new executor test.