### PR TITLE
feat(seismic-evm)!: own the purpose-key bundle (PurposeKeys replaces the enclave struct)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
-seismic-enclave = "0.1.0"
+seismic-crypto = "0.1.0"
 seismic-revm = { version = "1.0.0", default-features =  false }
 
 alloy-evm = { version = "0.20.1", path = "crates/evm", default-features = false }
@@ -64,6 +64,7 @@ op-revm = { version = "10.0.0", default-features = false }
 
 # misc
 auto_impl = "1"
+secp256k1 = { version = "0.30", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["full"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
@@ -71,7 +72,11 @@ serde_json = "1"
 
 [patch.crates-io]
 # enclave
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
+# seismic-enclave is not used anymore but resolved transitively (seismic-alloy-consensus imports
+# the facade); the entry keeps it on the same pin as seismic-crypto. We will get rid of this dep
+# once we update seismic-alloy to use seismic-crypto instead of seismic-enclave.
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
 
 # alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -86,8 +91,8 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
 
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy.git", tag = "v1.1.0" }

--- a/crates/seismic-evm/Cargo.toml
+++ b/crates/seismic-evm/Cargo.toml
@@ -27,14 +27,15 @@ revm.workspace = true
 # seismic
 seismic-revm.workspace = true
 
-seismic-enclave.workspace = true
 seismic-alloy-consensus = { workspace = true, features = ["std", "serde"] }
 
 # misc
 auto_impl.workspace = true
+secp256k1.workspace = true
 
 [dev-dependencies]
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+seismic-crypto.workspace = true
 
 [features]
 default = ["std"]
@@ -44,4 +45,5 @@ std = [
 	"revm/std",
 	"alloy-evm/std",
 	"seismic-revm/std",
+	"secp256k1/std",
 ]

--- a/crates/seismic-evm/src/block/mod.rs
+++ b/crates/seismic-evm/src/block/mod.rs
@@ -80,7 +80,7 @@ where
     R::Receipt: std::fmt::Debug,
 {
     inner: EthBlockExecutor<'a, Evm, Spec, R>,
-    purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+    purpose_keys: &'static crate::PurposeKeys,
 }
 
 impl<'a, E, Spec, R> SeismicBlockExecutor<'a, E, Spec, R>
@@ -96,7 +96,7 @@ where
         ctx: SeismicBlockExecutionCtx<'a>,
         spec: Spec,
         receipt_builder: R,
-        purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+        purpose_keys: &'static crate::PurposeKeys,
     ) -> Self {
         Self { inner: EthBlockExecutor::new(evm, ctx, spec, receipt_builder), purpose_keys }
     }
@@ -308,7 +308,7 @@ pub struct SeismicBlockExecutorFactory<
     /// EVM factory.
     evm_factory: EvmFactory,
     /// Purpose keys for decryption.
-    pub purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+    pub purpose_keys: &'static crate::PurposeKeys,
 }
 
 impl<R, Spec, EvmFactory> SeismicBlockExecutorFactory<R, Spec, EvmFactory> {
@@ -318,7 +318,7 @@ impl<R, Spec, EvmFactory> SeismicBlockExecutorFactory<R, Spec, EvmFactory> {
         receipt_builder: R,
         spec: Spec,
         evm_factory: EvmFactory,
-        purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+        purpose_keys: &'static crate::PurposeKeys,
     ) -> Self {
         Self { receipt_builder, spec, evm_factory, purpose_keys }
     }
@@ -374,6 +374,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PurposeKeys;
     use alloy_consensus::SignableTransaction;
     use alloy_evm::EvmEnv;
     use alloy_primitives::{aliases::U96, keccak256, Bytes, Signature, TxKind, B256, U256};
@@ -382,14 +383,12 @@ mod tests {
         context::{BlockEnv, CfgEnv},
         database::{InMemoryDB, StateBuilder},
     };
+    use secp256k1::{rand, PublicKey, Secp256k1, SecretKey};
     use seismic_alloy_consensus::{
         TxLegacyFields, TxSeismic, TxSeismicElements, TxSeismicMetadata,
     };
-    use seismic_enclave::{
-        get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-        get_unsecure_sample_secp256k1_sk,
-        secp256k1::{rand, PublicKey, Secp256k1, SecretKey},
-        GetPurposeKeysResponse, Nonce,
+    use seismic_crypto::{
+        get_unsecure_sample_secp256k1_pk, get_unsecure_sample_secp256k1_sk, Nonce,
     };
     use seismic_revm::SeismicSpecId;
 
@@ -426,7 +425,7 @@ mod tests {
         signing_key: SigningKey,
         executor_factory: SeismicBlockExecutorFactory,
         ctx: SeismicBlockExecutionCtx<'a>,
-        purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+        purpose_keys: &'static crate::PurposeKeys,
         encryption_pubkey: PublicKey,
         encryption_sk: SecretKey,
         encryption_nonce: Nonce,
@@ -474,12 +473,14 @@ mod tests {
         }
     }
 
-    fn get_mock_keys() -> GetPurposeKeysResponse {
-        GetPurposeKeysResponse {
+    fn get_mock_keys() -> PurposeKeys {
+        PurposeKeys {
+            // The tx-io pair must be a valid keypair — tests encrypt to the pk
+            // and the executor decrypts with the sk. The rng value is arbitrary:
+            // no test here asserts RNG-precompile output.
             tx_io_sk: get_unsecure_sample_secp256k1_sk(),
             tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            snapshot_key_bytes: [0u8; 32],
-            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
+            rng_ikm: [0u8; 64],
         }
     }
 

--- a/crates/seismic-evm/src/lib.rs
+++ b/crates/seismic-evm/src/lib.rs
@@ -31,6 +31,31 @@ use seismic_revm::{
 pub mod block;
 pub mod hardfork;
 
+pub use secp256k1;
+
+/// The per-purpose keys a node boots with. reth assembles this from the
+/// custodian socket (TEE nodes) or from its well-known constants (pre-TEE
+/// networks) and threads it by reference into the EVM factories.
+#[derive(Clone)]
+pub struct PurposeKeys {
+    /// Secret half of the network's tx-io keypair: decrypts shielded calldata.
+    pub tx_io_sk: secp256k1::SecretKey,
+    /// Public half of the network's tx-io keypair: wallets ECDH against it to
+    /// encrypt calldata.
+    pub tx_io_pk: secp256k1::PublicKey,
+    /// HKDF ikm seeding the RNG precompile: the secret half of the derived
+    /// schnorrkel keypair (`secret.to_bytes()`). Consumers only ever feed it
+    /// to HKDF — no schnorrkel crypto is performed with it.
+    pub rng_ikm: [u8; 64],
+}
+
+/// Redacted: `tx_io_sk` and `rng_ikm` are secrets.
+impl core::fmt::Debug for PurposeKeys {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PurposeKeys").field("tx_io_pk", &self.tx_io_pk).finish_non_exhaustive()
+    }
+}
+
 /// Seismic EVM implementation.
 ///
 /// This is a wrapper type around the `revm` evm with optional [`Inspector`] (tracing)
@@ -261,14 +286,12 @@ where
 // Factory that creates SeismicEVMs with pre-fetched purpose keys.
 // The purpose keys are provided at boot time and stored globally.
 pub struct SeismicEvmFactory {
-    purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
+    purpose_keys: &'static PurposeKeys,
 }
 
 impl SeismicEvmFactory {
     /// Creates a new [`SeismicEvmFactory`] with pre-fetched purpose keys.
-    pub fn new_with_purpose_keys(
-        purpose_keys: &'static seismic_enclave::GetPurposeKeysResponse,
-    ) -> Self {
+    pub fn new_with_purpose_keys(purpose_keys: &'static PurposeKeys) -> Self {
         Self { purpose_keys }
     }
 
@@ -292,7 +315,7 @@ impl SeismicEvmFactory {
 
     /// Create SeismicContext with the RNG key from purpose keys
     fn create_context_with_rng_key(&self) -> SeismicContext<EmptyDB> {
-        SeismicContext::seismic_with_rng_key(self.purpose_keys.rng_keypair.clone())
+        SeismicContext::seismic_with_rng_key(self.purpose_keys.rng_ikm)
     }
 
     /// Create an EVM with inspector using the stored RNG keypair.


### PR DESCRIPTION
The bundle of keys a node boots with is a consumer-side concern — reth assembles it (from the custodian socket or its well-known constants) and threads it by reference into the EVM factories defined here — so this crate now defines it: `alloy_seismic_evm::PurposeKeys { tx_io_sk, tx_io_pk, rng_ikm: [u8; 64] }`, with a redacted `Debug` and a `secp256k1` re-export so consumers name the key types without version-matching. It replaces `seismic_enclave::GetPurposeKeysResponse` in the factory and executor signatures; the enclave repo deleted the type (SeismicSystems/enclave#218) and keeps custody strictly per-purpose.

- The rng key is carried as raw HKDF ikm bytes and handed to `seismic_with_rng_key([u8; 64])` (seismic-revm#223); tx decryption uses `tx_io_sk` unchanged.
- The direct `seismic-enclave` dependency is gone: tests take their sample keys from the narrow `seismic-crypto` crate. The facade stays pinned only for the transitive seismic-alloy-consensus edge (see the patch-entry comment).
- Pins: enclave at 8274f14 (PurposeKeysRpc retired; seismic-crypto gains the secp256k1 re-export), seismic-revm at 7a3dd39 (the rng-ikm API).
- The test mock's rng value is an arbitrary constant — no test here asserts RNG-precompile output; its tx-io pair remains a real keypair (tests encrypt to the pk, the executor decrypts with the sk).