### PR TITLE
fix(hardfork): SeismicChainHardforks must report Prague active (off-by-one)

### DIFF
--- a/crates/seismic-evm/src/hardfork.rs
+++ b/crates/seismic-evm/src/hardfork.rs
@@ -55,8 +55,17 @@ impl SeismicChainHardforks {
 
 impl EthereumHardforks for SeismicChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        if fork < EthereumHardfork::Prague {
-            // We assume that Seismic chains were launched with all forks before Prague activated.
+        if fork <= EthereumHardfork::Prague {
+            // We assume that Seismic chains were launched with all forks through Prague
+            // activated. Prague itself must be included here (not just forks strictly
+            // before it): seismic-reth's own hardfork schedule activates Prague at genesis
+            // (ForkCondition::Timestamp(0)), and Mercury extends Prague's precompile set
+            // (see seismic-revm's test_cancun_precompiles_in_mercury, which builds Mercury's
+            // precompiles as a superset of Precompiles::prague()). Reporting Prague as never
+            // active here caused EIP-6110/7002/7251 system calls in
+            // EthBlockExecutor::finish (crates/evm/src/eth/block.rs) to be silently skipped
+            // for any consumer using this Spec, since that gate is
+            // `spec.is_prague_active_at_timestamp(..)`.
             ForkCondition::Block(0)
         } else {
             ForkCondition::Never
@@ -73,5 +82,28 @@ impl SeismicHardforks for SeismicChainHardforks {
 impl EthExecutorSpec for SeismicChainHardforks {
     fn deposit_contract_address(&self) -> Option<Address> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the off-by-one in `ethereum_fork_activation`: the comparison used
+    /// to be `fork < EthereumHardfork::Prague`, which excluded Prague itself and made
+    /// `is_prague_active_at_timestamp` return false at every timestamp. That gate is exactly
+    /// what `EthBlockExecutor::finish` (in `crates/evm/src/eth/block.rs`) checks before running
+    /// the EIP-6110/7002/7251 system calls, so this silently skipped them for any consumer
+    /// using this Spec.
+    #[test]
+    fn test_prague_active_at_genesis() {
+        let hardforks = SeismicChainHardforks::seismic_mainnet();
+        assert!(
+            hardforks.is_prague_active_at_timestamp(0),
+            "Prague must be active at genesis on Seismic chains -- seismic-reth's own \
+             hardfork schedule activates Prague at ForkCondition::Timestamp(0), and Mercury \
+             extends Prague's precompile set (see seismic-revm's \
+             test_cancun_precompiles_in_mercury)"
+        );
     }
 }


### PR DESCRIPTION
Closes #63.

`SeismicChainHardforks::ethereum_fork_activation` reported Prague as never active — the comparison was `fork < EthereumHardfork::Prague`, which excludes Prague itself.

## Why this is wrong
- `seismic-reth`'s own hardfork schedule (`crates/seismic/hardforks/src/lib.rs`) activates Prague at `ForkCondition::Timestamp(0)` — Prague **is** active from genesis in the real, production chainspec.
- `seismic-revm`'s own test (`test_cancun_precompiles_in_mercury`) builds Mercury's precompile set as an extension of `Precompiles::prague()`, i.e. Mercury is meant to include everything Prague introduces.

## Impact
`EthBlockExecutor::finish` (`crates/evm/src/eth/block.rs`) gates the EIP-6110 (deposits), EIP-7002 (withdrawal requests), and EIP-7251 (consolidation requests) system calls directly on `self.spec.is_prague_active_at_timestamp(timestamp_seconds)`. With the old comparison, that's always `false`, so those system calls were silently skipped and the block's `requests` field would never be populated.

`SeismicChainHardforks` is also the default `Spec` type parameter for the exported `SeismicBlockExecutorFactory<R, Spec, EvmFactory>`, and it's what this crate's own tests use to exercise the block executor (`SeismicChainHardforks::seismic_mainnet()` in `crates/seismic-evm/src/block/mod.rs`).

**This does not affect `seismic-reth` in production** — it supplies its own chainspec type instead of this default, so the actual node isn't hitting this. But any other consumer of this crate relying on the default `Spec`, and this crate's own test suite, would be.

## Fix
Changes the comparison to `fork <= EthereumHardfork::Prague` (Prague inclusive), matching the existing `ForkCondition::Block(0)` treatment already used for every other pre-Prague fork in this same function — no new condition type introduced, just widening the existing correct pattern by one.

## Test
Adds a regression test asserting `is_prague_active_at_timestamp(0)` is `true` for `SeismicChainHardforks::seismic_mainnet()`. This file had no tests before.
